### PR TITLE
chore(build): fix build for 21.10

### DIFF
--- a/httploader/configs.xml
+++ b/httploader/configs.xml
@@ -4,7 +4,7 @@
     <email>contact@centreon.com</email>
     <website>http://www.centreon.com</website>
     <description>This widget displays the content of any URI in your custom view. Good idea to display some Intranet page, the Centreon official documentation or the weather forecast!</description>
-    <version>21.10.0-beta.1</version>
+    <version>21.10.0</version>
     <keywords>centreon, widget, url, http</keywords>
     <screenshot></screenshot>
     <thumbnail>./widgets/httploader/resources/centreon-logo.png</thumbnail>


### PR DESCRIPTION
Fixing build for the 21.10.

The version specified in the config.xml is used in the spectemplate of the widget. The spectemplate does not allow -beta.1 as version prefix