### PR TITLE
fix(chore): define db extension files as SQL

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,3 +4,6 @@ sonar.projectName={PROJECT_NAME}
 sonar.projectVersion={PROJECT_VERSION}
 
 sonar.sources=./httploader
+
+sonar.tsql.file.suffixes=sql,tsql
+sonar.plsql.file.suffixes=pks,pkb


### PR DESCRIPTION
## Description

Define DB extension files as T/SQL and not oracle on sonarQube (PL/SQL)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)
